### PR TITLE
docs: add Contributor Covenant CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity, expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Demonstrating empathy and kindness
+- Respecting differing viewpoints and experiences
+- Accepting constructive criticism
+- Showing responsibility and accountability
+
+Examples of unacceptable behavior:
+- Harassment or discriminatory jokes
+- Trolling, insulting or derogatory comments
+- Publishing others' private information
+- Sustained disruption of discussions
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards and taking corrective action when needed.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to @portiajefferson.
+
+---
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
Adds a community Code of Conduct based on the Contributor Covenant v2.1.
This defines expectations for inclusive, respectful collaboration aligned with open-source best practices.

Reference: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

Closes #<issue-number> (if applicable)
