### PR TITLE
docs: add individual team role files to /docs

### DIFF
--- a/docs/roles/ai-integration.md
+++ b/docs/roles/ai-integration.md
@@ -1,0 +1,17 @@
+# 🤖 AI Engineer – LLM Assistant & Prompt Design
+
+## Responsibilities
+- Integrate OpenAI API or Azure OpenAI
+- Build assistant flow and prompt logic
+- Test chatbot output and constraints
+
+## Tasks
+- [ ] Set up API environment variables
+- [ ] Build initial prompt chain for housing questions
+- [ ] Handle API rate limits/errors
+- [ ] Link assistant to Streamlit frontend
+
+## Tools Used
+- OpenAI Python SDK
+- LangChain (if used)
+- GitHub CI/CD (for prompt testing)

--- a/docs/roles/data-analyst.md
+++ b/docs/roles/data-analyst.md
@@ -1,0 +1,16 @@
+# 📊 Data Analyst – Maps, Risk Scoring, Power BI
+
+## Responsibilities
+- Connect data layers (HOLC maps, census data)
+- Develop scoring engine for housing instability
+- Optionally create Power BI dashboards
+
+## Tasks
+- [ ] Load GIS/redlining map overlays
+- [ ] Develop property risk scoring algorithm
+- [ ] Build Power BI visuals (if time permits)
+
+## Tools Used
+- Azure Maps
+- GeoPandas / Pandas
+- Power BI / Power Platform

--- a/docs/roles/devops.md
+++ b/docs/roles/devops.md
@@ -1,0 +1,16 @@
+# 🛠️ DevOps Lead – GitHub Actions & Testing
+
+## Responsibilities
+- Maintain CI/CD workflows
+- Configure and monitor lint/test pipelines
+- Help teammates with Git branches and PRs
+
+## Tasks
+- [ ] Update `.github/workflows/ci.yml`
+- [ ] Review failed jobs and debug flake8/test issues
+- [ ] Add badge to README
+
+## Tools Used
+- GitHub Actions
+- Flake8
+- `unittest` / `pytest`

--- a/docs/roles/frontend.md
+++ b/docs/roles/frontend.md
@@ -1,0 +1,17 @@
+# 🎨 Frontend Developer – Streamlit
+
+## Responsibilities
+- Design and implement layout using Streamlit
+- Build navigation tabs and responsive components
+- Ensure accessibility and usability
+
+## Tasks
+- [ ] Create app layout (header/sidebar)
+- [ ] Add tabs for Redlining Map, AI Assistant, About
+- [ ] Style components and improve visual flow
+- [ ] Link frontend to LLM and map modules
+
+## Tools Used
+- Streamlit
+- Python
+- GitHub issues and branches

--- a/docs/roles/project-manager.md
+++ b/docs/roles/project-manager.md
@@ -1,0 +1,19 @@
+# 🧭 Project Manager Role – Portia Jefferson
+
+## Responsibilities
+- Organize milestones and GitHub Projects board
+- Assign and review pull requests
+- Coordinate timelines with hackathon deadlines
+- Maintain contributor guidelines and documentation
+
+## Tasks
+- [ ] Add/track issues in GitHub Projects
+- [ ] Approve/merge PRs after review
+- [ ] Set up automation rules
+- [ ] Monitor CI/CD and testing failures
+
+## Tools Used
+- GitHub Projects
+- GitHub Actions
+- Discussions
+- Issue templates / pull request templates


### PR DESCRIPTION
This commit adds five markdown files detailing responsibilities and tasks for:
- Project Manager
- Frontend Developer
- AI Integration Engineer
- Data Analyst
- DevOps Lead

All files were placed in the `/docs` directory to help teammates quickly find their roles and responsibilities during development.